### PR TITLE
Add Video Coding Mode support to allow MBAFF and PAFF encoding

### DIFF
--- a/Common.h
+++ b/Common.h
@@ -44,6 +44,7 @@ struct Parameters
     _HAPI_VIDEO_CAPTURE_SOURCE videoInput;
     _HAPI_AUDIO_CAPTURE_SOURCE audioInput;
     _HAPI_RATE_CONTROL     videoRateControl;
+    _HAPI_CODING_MODE      videoCodingMode;
     _HAPI_VIDEO_PROFILE    videoProfile;
     _HAPI_VIDEO_H264_LEVEL videoH264Level;
     _HAPI_LATENCY          videoLatency;

--- a/HauppaugeDev.cpp
+++ b/HauppaugeDev.cpp
@@ -93,7 +93,7 @@ void HauppaugeDev::configure(void)
     RegistryAccess::writeDword("VideoOutputBitrate", m_params.videoBitrate);
     RegistryAccess::writeDword("VBRMin", m_params.videoVBRMin);
     RegistryAccess::writeDword("VBRMax", m_params.videoVBRMax);
-
+    RegistryAccess::writeDword("VideoCodingMode", m_params.videoCodingMode);
     RegistryAccess::writeDword("VideoProfile", m_params.videoProfile);
     RegistryAccess::writeDword("Profile", m_params.videoProfile);
 

--- a/hauppauge2.cpp
+++ b/hauppauge2.cpp
@@ -202,6 +202,8 @@ int main(int argc, char *argv[])
          "Video bitrate")
         ("videoratecontrol,C", po::value<int>()->default_value(1),
          "Video rate type (0=CBR, 1=VBR, 2=CAPPED_VBR)")
+        ("videocodingmode,X", po::value<int>()->default_value(1),
+         "Video coding mode type (0=Frame, 1=Field, 2=MBAFF, 3=PAFF)")
         ("minvbrrate,m", po::value<int>()->default_value(9000000),
          "Mininum VBR bitrate")
         ("maxvbrrate,M", po::value<int>()->default_value(20000000),
@@ -371,6 +373,9 @@ int main(int argc, char *argv[])
     if (vm.count("videoratecontrol"))
         params.videoRateControl = static_cast<_HAPI_RATE_CONTROL>
                                     (vm["videoratecontrol"].as<int>());
+    if (vm.count("videocodingmode"))
+        params.videoCodingMode = static_cast<_HAPI_CODING_MODE>
+                                    (vm["videocodingmode"].as<int>());
     if (vm.count("minvbrrate"))
         params.videoVBRMin = vm["minvbrrate"].as<int>();
     if (vm.count("maxvbrrate"))


### PR DESCRIPTION
I added a videocodingmode option to enable MBAFF and PAFF encoding. I chose X as the short form for no real reason.  It seems to work in my limited testing - with MediaInfo reporting MBAFF interleaved field encoding rather than separate field encoding for 1080i25 content.